### PR TITLE
Release/1.10.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -24,21 +24,21 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "Core",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.4.5.xcframework.zip",
-            checksum : "14a04c8daf65595004027ae830c09c70a1fc6e63995ae2f3b5b149786ed8eba0"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.4.6.xcframework.zip",
+            checksum : "a5aae671af5dd526e1ab4cdb4a8bfd411ed38c831b1b67657f90f4cb9000272a"
         ),
         .binaryTarget(
             name: "Banner",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.9.1.xcframework.zip",
-            checksum : "db1d699ecd2239e537ba2372fecf98783c2d8a84e83f0b00193a38ae5a793db1",
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.9.2.xcframework.zip",
+            checksum : "386b76dec8fd0d49a8ae7704809d88aa049f3859caaf02acd9581f19dec73d1d",
             dependencies: [
                 "Core"
             ]
         ),
         .binaryTarget(
             name: "OMAdapter",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.0.7.xcframework.zip",
-            checksum : "3e8ef20acf3ed3514e25130a7b689ea5f66eb1d9cdd608e697597dca950c5c3e",
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.0.8.xcframework.zip",
+            checksum : "458affe2462cc833f072f69616f1f2faf8b8139f959d959196429fd83fd9790d",
             dependencies: [
                 "Banner",
                 "OMSDK",

--- a/Package.swift
+++ b/Package.swift
@@ -34,12 +34,12 @@ let package = Package(
         .binaryTarget(
             name: "Banner",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.9.2.xcframework.zip",
-            checksum : "386b76dec8fd0d49a8ae7704809d88aa049f3859caaf02acd9581f19dec73d1d",
+            checksum : "386b76dec8fd0d49a8ae7704809d88aa049f3859caaf02acd9581f19dec73d1d"
         ),
         .binaryTarget(
             name: "OMAdapter",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.0.8.xcframework.zip",
-            checksum : "458affe2462cc833f072f69616f1f2faf8b8139f959d959196429fd83fd9790d",
+            checksum : "458affe2462cc833f072f69616f1f2faf8b8139f959d959196429fd83fd9790d"
         ),
         .binaryTarget(
             name: "OMSDK",

--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,17 @@ let package = Package(
         .library(
             name: "RUNABanner",
             targets: [
+                "Core",
                 "Banner",
             ]
         ),
         .library(
             name: "RUNAOMAdapter",
             targets: [
+                "Core",
+                "Banner",
                 "OMAdapter",
+                "OMSDK",
             ]
         ),
     ],
@@ -31,18 +35,11 @@ let package = Package(
             name: "Banner",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.9.2.xcframework.zip",
             checksum : "386b76dec8fd0d49a8ae7704809d88aa049f3859caaf02acd9581f19dec73d1d",
-            dependencies: [
-                "Core"
-            ]
         ),
         .binaryTarget(
             name: "OMAdapter",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.0.8.xcframework.zip",
             checksum : "458affe2462cc833f072f69616f1f2faf8b8139f959d959196429fd83fd9790d",
-            dependencies: [
-                "Banner",
-                "OMSDK",
-            ]
         ),
         .binaryTarget(
             name: "OMSDK",

--- a/Package.swift
+++ b/Package.swift
@@ -10,39 +10,39 @@ let package = Package(
         .library(
             name: "RUNABanner",
             targets: [
-                "Core",
-                "Banner",
+                "RUNACore",
+                "RUNABanner",
             ]
         ),
         .library(
             name: "RUNAOMAdapter",
             targets: [
-                "Core",
-                "Banner",
-                "OMAdapter",
-                "OMSDK",
+                "RUNACore",
+                "RUNABanner",
+                "RUNAOMAdapter",
+                "OMSDK_Rakuten",
             ]
         ),
     ],
     dependencies: [],
     targets: [
         .binaryTarget(
-            name: "Core",
+            name: "RUNACore",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.4.6.xcframework.zip",
             checksum : "a5aae671af5dd526e1ab4cdb4a8bfd411ed38c831b1b67657f90f4cb9000272a"
         ),
         .binaryTarget(
-            name: "Banner",
+            name: "RUNABanner",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.9.2.xcframework.zip",
             checksum : "386b76dec8fd0d49a8ae7704809d88aa049f3859caaf02acd9581f19dec73d1d"
         ),
         .binaryTarget(
-            name: "OMAdapter",
+            name: "RUNAOMAdapter",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.0.8.xcframework.zip",
             checksum : "458affe2462cc833f072f69616f1f2faf8b8139f959d959196429fd83fd9790d"
         ),
         .binaryTarget(
-            name: "OMSDK",
+            name: "OMSDK_Rakuten",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.3.31.xcframework.zip",
             checksum : "9f5e075651c1c254f6016dd9bc2e8d8e45d6ba2843f8d4c4299e6de6446b31ed"
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -8,30 +8,46 @@ let package = Package(
     platforms: [.iOS(.v10)],
     products: [
         .library(
-            name: "RUNA",
+            name: "RUNABanner",
             targets: [
-                "RUNACore", 
-                "RUNABanner",
-                "RUNAOMAdapter",
+                "Banner",
             ]
-        )
+        ),
+        .library(
+            name: "RUNAOMAdapter",
+            targets: [
+                "OMAdapter",
+            ]
+        ),
     ],
     dependencies: [],
     targets: [
         .binaryTarget(
-            name: "RUNACore",
+            name: "Core",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.4.5.xcframework.zip",
             checksum : "14a04c8daf65595004027ae830c09c70a1fc6e63995ae2f3b5b149786ed8eba0"
         ),
         .binaryTarget(
-            name: "RUNABanner",
+            name: "Banner",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.9.1.xcframework.zip",
-            checksum : "db1d699ecd2239e537ba2372fecf98783c2d8a84e83f0b00193a38ae5a793db1"
+            checksum : "db1d699ecd2239e537ba2372fecf98783c2d8a84e83f0b00193a38ae5a793db1",
+            dependencies: [
+                "Core"
+            ]
         ),
         .binaryTarget(
-            name: "RUNAOMAdapter",
+            name: "OMAdapter",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.0.7.xcframework.zip",
-            checksum : "3e8ef20acf3ed3514e25130a7b689ea5f66eb1d9cdd608e697597dca950c5c3e"
+            checksum : "3e8ef20acf3ed3514e25130a7b689ea5f66eb1d9cdd608e697597dca950c5c3e",
+            dependencies: [
+                "Banner",
+                "OMSDK",
+            ]
+        ),
+        .binaryTarget(
+            name: "OMSDK",
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.3.31.xcframework.zip",
+            checksum : "9f5e075651c1c254f6016dd9bc2e8d8e45d6ba2843f8d4c4299e6de6446b31ed"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ pod 'RUNA/OMAdapter'
 
 ### Swift Package Manager
 
-Swift Package Manager distribution support from 1.10.1.
+Swift Package Manager distribution support from 1.10.2 (1.10.1 deprecated).
 
-Add Package's URL `https://github.com/rakuten-ads/Rakuten-Ads-iOS` in Xcode.
+Please use package's URL `https://github.com/rakuten-ads/Rakuten-Ads-iOS` in Xcode,
+
+and select libraries from `RUNABanner`, `RUNAOMAdapter`.
+
+`RUNAOMAdapter` is essential for the Open Measurement request. 
 
 
 ### M1 support

--- a/RUNA/1.10.2/RUNA.podspec
+++ b/RUNA/1.10.2/RUNA.podspec
@@ -1,0 +1,49 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNA"
+  s.version      = "1.10.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :git => "https://github.com/rakuten-ads/Rakuten-Ads-iOS.git"
+  }
+
+  s.default_subspec = 'Banner'
+
+  s.subspec 'CoreOnly' do |ss|
+    ss.ios.dependency 'RUNACore', '1.4.6'
+  end
+
+  s.subspec 'Banner' do |ss|
+    ss.dependency 'RUNA/CoreOnly'
+    ss.ios.dependency 'RUNABanner', '1.9.2'
+  end
+
+  s.subspec 'OMSDK' do |ss|
+    ss.ios.dependency 'RUNAOMSDK', '1.3.31'
+  end
+
+  s.subspec 'OMAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.dependency 'RUNA/OMSDK'
+    ss.ios.dependency 'RUNAOMAdapter', '1.0.8'
+  end
+
+end

--- a/RUNABanner/1.9.2/RUNABanner.podspec
+++ b/RUNABanner/1.9.2/RUNABanner.podspec
@@ -1,0 +1,32 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNABanner"
+  s.version      = "1.9.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNACore', '~> 1.4'
+
+end

--- a/RUNACore/1.4.6/RUNACore.podspec
+++ b/RUNACore/1.4.6/RUNACore.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNACore"
+  s.version      = "1.4.6"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit", "Network"
+
+end

--- a/RUNAOMAdapter/1.0.8/RUNAOMAdapter.podspec
+++ b/RUNAOMAdapter/1.0.8/RUNAOMAdapter.podspec
@@ -1,0 +1,33 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMAdapter"
+  s.version      = "1.0.8"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNABanner', '~> 1.9'
+  s.dependency 'RUNAOMSDK', '~> 1.3'
+
+end

--- a/RUNAOMSDK/1.3.31/RUNAOMSDK.podspec
+++ b/RUNAOMSDK/1.3.31/RUNAOMSDK.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMSDK"
+  s.version      = "1.3.31"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "OMSDK_Rakuten.xcframework"
+
+  s.frameworks = "Foundation", "UIKit"
+
+end


### PR DESCRIPTION
## Changes
- SPM support from Swift 5.5
- SPM support optional `RUNAOMAdapter` dependency
- Cocoapods add `RUNAOMSDK.podspec`

## Fixes
- code sign failed on nested OMSDK_Rakuten.xcframework, change to outer dependency

## Modules
RUNA 1.10.2
- RUNA/Banner 1.9.2
- RUNA/Core 1.4.6
- RUNA/OMAdapter 1.0.8
- RUNA/OMSDK 1.3.31