### PR TITLE
Release/1.15.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,23 +28,23 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "RUNACore",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.7.0.xcframework.zip",
-            checksum : "9785efa3aefd25019330c33029dd62da84804cc05c035640ac39a36319affea0"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.8.0.xcframework.zip",
+			checksum : "9a61185eb755bcfe73bec8f869064e86576dd9ecdff3563151eb8496fa15b621"
         ),
         .binaryTarget(
             name: "RUNABanner",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.13.0.xcframework.zip",
-            checksum : "dfc031fc6f1929e4b95ceecabed09b90e9c6fb816b00310d98acefe2faf71ca1"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.14.0.xcframework.zip",
+			checksum : "33cc7ee8507a519e456ff62c48ee36c0cf7af92b1c16ae540fe29dd94de03fe3"
         ),
         .binaryTarget(
             name: "RUNAOMAdapter",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.2.0.xcframework.zip",
-            checksum : "d80ab79fc780e0a07df7326d3767abf17779caf9d0cb9789b19f6f9e8ddba053"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.0.xcframework.zip",
+			checksum : "970ad2d481a91d40dc1634bd10bb61c68476398807c158157d3ef0d574f39846"
         ),
         .binaryTarget(
             name: "OMSDK_Rakuten",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.4.3.xcframework.zip",
-            checksum : "aa5a99ae1f1b64bac66b0beffa2aaadc8920842c3706aeb7e0508b19d29d70d5"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.4.11.xcframework.zip",
+            checksum : "4447450ee4f45c30cf53615f273f2dfda81fada03e79dec9b4f93a8a32e9319c"
         ),
     ]
 )

--- a/RUNA/1.15.0/RUNA.podspec
+++ b/RUNA/1.15.0/RUNA.podspec
@@ -1,0 +1,49 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNA"
+  s.version      = "1.15.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :git => "https://github.com/rakuten-ads/Rakuten-Ads-iOS.git"
+  }
+
+  s.default_subspec = 'Banner'
+
+  s.subspec 'CoreOnly' do |ss|
+    ss.ios.dependency 'RUNACore', '1.8.0'
+  end
+
+  s.subspec 'Banner' do |ss|
+    ss.dependency 'RUNA/CoreOnly'
+    ss.ios.dependency 'RUNABanner', '1.14.0'
+  end
+
+  s.subspec 'OMSDK' do |ss|
+    ss.ios.dependency 'RUNAOMSDK', '1.4.11'
+  end
+
+  s.subspec 'OMAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.dependency 'RUNA/OMSDK'
+    ss.ios.dependency 'RUNAOMAdapter', '1.3.0'
+  end
+
+end

--- a/RUNABanner/1.14.0/RUNABanner.podspec
+++ b/RUNABanner/1.14.0/RUNABanner.podspec
@@ -1,0 +1,32 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNABanner"
+  s.version      = "1.14.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNACore', '~> 1.8'
+
+end

--- a/RUNACore/1.8.0/RUNACore.podspec
+++ b/RUNACore/1.8.0/RUNACore.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNACore"
+  s.version      = "1.8.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit", "Network"
+
+end

--- a/RUNAOMAdapter/1.3.0/RUNAOMAdapter.podspec
+++ b/RUNAOMAdapter/1.3.0/RUNAOMAdapter.podspec
@@ -1,0 +1,33 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMAdapter"
+  s.version      = "1.3.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNABanner', '~> 1.14'
+  s.dependency 'RUNAOMSDK', '~> 1.4.11'
+
+end

--- a/RUNAOMSDK/1.4.11/RUNAOMSDK.podspec
+++ b/RUNAOMSDK/1.4.11/RUNAOMSDK.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMSDK"
+  s.version      = "1.4.11"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "OMSDK_Rakuten.xcframework"
+
+  s.frameworks = "Foundation", "UIKit"
+
+end

--- a/doc/bannerads/extension/README.md
+++ b/doc/bannerads/extension/README.md
@@ -112,14 +112,8 @@ bannerView.setEasyId("123456789")
 bannerView.setRpoint(123456)
 ```
 
-#### Geo
+---
 
-- latitude: `double`, from -90.0 to +90.0, where negative is south
-- longitude: `double`, from -180.0 to +180.0, where negative is west
+LANGUAGE :
 
-![Language](http://img.shields.io/badge/language-Swift-red.svg?style=flat)
-```Swift
-let lat = location.coordinate.latitude
-let lon = location.coordinate.longitude
-bannerView.setLocation(latitude: lat, longitude: lon)
-```
+> [![ja](/doc/lang/ja.png)](/doc/ja/bannerads/extension/README.md)

--- a/doc/ja/bannerads/extension/README.md
+++ b/doc/ja/bannerads/extension/README.md
@@ -112,18 +112,6 @@ bannerView.setEasyId("123456789")
 bannerView.setRpoint(123456)
 ```
 
-#### 地理情報
-
-- latitude: `double`, 値は -90.0 から +90.0 まで, マイナス値は南を表す
-- longitude: `double`, 値は -180.0 から +180.0 まで, マイナス値は西を表す
-
-![Language](http://img.shields.io/badge/language-Swift-red.svg?style=flat)
-```Swift
-let lat = location.coordinate.latitude
-let lon = location.coordinate.longitude
-bannerView.setLocation(latitude: lat, longitude: lon)
-```
-
 ---
 
 LANGUAGE :


### PR DESCRIPTION
## Changes
- Add `PrivacyInfo.xcprivacy` files to support for Apple Privacy Manifest request
- removed the use of App Tracking Transparency framework(ATT)
- removed unsupported API `setLocation`

#### References of Apple Privacy Manifest
  - see first announcement for [Privacy updates for App Store submissions](https://developer.apple.com/news/?id=r1henawx)
  - latest update[App privacy details on the App Store](https://developer.apple.com/app-store/app-privacy-details/#whats-new)


## Modules

RUNA 1.15.0
- RUNA/Banner 1.13.0 → 1.14.0
- RUNA/Core 1.7.0 → 1.8.0
- RUNA/OMAdapter 1.2.0 → 1.3.0
- RUNA/OMSDK 1.4.3 -> 1.4.11
