### PR TITLE
Release/1.15.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,23 +28,23 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "RUNACore",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.8.1.xcframework.zip",
-			checksum : "db07ab7e04b7f33426f59130fcc4a74996681ee27907f1991e428f46608ddc7a"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.8.2.xcframework.zip",
+			checksum : "305fed8674362ffdda2e29403f45aaf6fab0a402d4dc0686cd25417ede4ebb58"
         ),
         .binaryTarget(
             name: "RUNABanner",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.14.1.xcframework.zip",
-			checksum : "ca933f86b355b5ab401f693facfae4b76735825d83f3682abc8f418d3930bf0b"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.14.2.xcframework.zip",
+			checksum : "8a2046dd3ab255ef63a983dedef4699ee7db3f03cfe95b97b15784595f33d89c"
         ),
         .binaryTarget(
             name: "RUNAOMAdapter",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.1.xcframework.zip",
-			checksum : "fb56046598777bd19a1b8a3c6a9dfd5b46df54d0bccb352ca4e753ff55d7d644"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.2.xcframework.zip",
+			checksum : "221e2e02b8db0e84b1af5e8a6c9b3c403e858a81d4b69bedacc520c421d880d5"
         ),
         .binaryTarget(
             name: "OMSDK_Rakuten",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.4.12.xcframework.zip",
-            checksum : "07e994bfa8f236979d61a2b5c4bff2a2ecaf011a394aaee4c6f71f9f631907c9"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.4.13.xcframework.zip",
+            checksum : "180907f36fd797969839123a4845a7e929af7ee7f2f51326419e3060fef551e0"
         ),
     ]
 )

--- a/RUNA/1.15.2/RUNA.podspec
+++ b/RUNA/1.15.2/RUNA.podspec
@@ -1,0 +1,49 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNA"
+  s.version      = "1.15.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :git => "https://github.com/rakuten-ads/Rakuten-Ads-iOS.git"
+  }
+
+  s.default_subspec = 'Banner'
+
+  s.subspec 'CoreOnly' do |ss|
+    ss.ios.dependency 'RUNACore', '1.8.2'
+  end
+
+  s.subspec 'Banner' do |ss|
+    ss.dependency 'RUNA/CoreOnly'
+    ss.ios.dependency 'RUNABanner', '1.14.2'
+  end
+
+  s.subspec 'OMSDK' do |ss|
+    ss.ios.dependency 'RUNAOMSDK', '1.4.13'
+  end
+
+  s.subspec 'OMAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.dependency 'RUNA/OMSDK'
+    ss.ios.dependency 'RUNAOMAdapter', '1.3.2'
+  end
+
+end

--- a/RUNABanner/1.14.2/RUNABanner.podspec
+++ b/RUNABanner/1.14.2/RUNABanner.podspec
@@ -1,0 +1,32 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNABanner"
+  s.version      = "1.14.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNACore', '~> 1.8'
+
+end

--- a/RUNACore/1.8.2/RUNACore.podspec
+++ b/RUNACore/1.8.2/RUNACore.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNACore"
+  s.version      = "1.8.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit", "Network"
+
+end

--- a/RUNAOMAdapter/1.3.2/RUNAOMAdapter.podspec
+++ b/RUNAOMAdapter/1.3.2/RUNAOMAdapter.podspec
@@ -1,0 +1,33 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMAdapter"
+  s.version      = "1.3.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNABanner', '~> 1.14'
+  s.dependency 'RUNAOMSDK', '~> 1.4.11'
+
+end

--- a/RUNAOMSDK/1.4.13/RUNAOMSDK.podspec
+++ b/RUNAOMSDK/1.4.13/RUNAOMSDK.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMSDK"
+  s.version      = "1.4.13"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "OMSDK_Rakuten.xcframework"
+
+  s.frameworks = "Foundation", "UIKit"
+
+end


### PR DESCRIPTION
## Changes
- replaced the signature of SDK with new certificate.
![Screenshot 2024-04-30 at 11 52 47](https://github.com/rakuten-ads/Rakuten-Ads-iOS/assets/45650052/4a120f34-9902-4adf-949e-de79e80bcaf3)

> It is safe to accept a confirmation dialog about team name has been changed  from `Daiji Ito` to `Rakuten Group, Inc` in latest Xcode 15.

## Modules

RUNA 1.15.2
- RUNA/Banner 1.14.1 → 1.14.2
- RUNA/Core 1.8.1 → 1.8.2
- RUNA/OMAdapter 1.3.1 → 1.3.2
- RUNA/OMSDK 1.4.12 -> 1.4.13