### PR TITLE
Release/1.17.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .binaryTarget(
             name: "RUNAOMAdapter",
             url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.3.xcframework.zip",
-            checksum : "221e2e02b8db0e84b1af5e8a6c9b3c403e858a81d4b69bedacc520c421d880d5"
+			checksum : "0ce1c4cb185c8107262c5e87e1d3f2b11995b1f4550c72095acc708046c17e09"
         ),
         .binaryTarget(
             name: "OMSDK_Rakuten",

--- a/Package.swift
+++ b/Package.swift
@@ -47,18 +47,18 @@ let package = Package(
         ),
         .binaryTarget(
             name: "RUNABanner",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.14.6.xcframework.zip",
-			checksum : "9ae269f78a7a51f11c764144c5954da12206e2282bdc4acfa3402587ae2d086d"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.15.0.xcframework.zip",
+			checksum : "fd3a640c140d230c99e19f12779f6afb4243d8117f389b46ca4dc035069ee7ae"
         ),
         .binaryTarget(
             name: "RUNAOMAdapter",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.2.xcframework.zip",
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.3.xcframework.zip",
             checksum : "221e2e02b8db0e84b1af5e8a6c9b3c403e858a81d4b69bedacc520c421d880d5"
         ),
         .binaryTarget(
             name: "OMSDK_Rakuten",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.4.13.xcframework.zip",
-            checksum : "180907f36fd797969839123a4845a7e929af7ee7f2f51326419e3060fef551e0"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMSDK/RUNAOMSDK_iOS_1.5.2.xcframework.zip",
+            checksum : "577e954e53c7ee31a89f413b836423543622ab5d721b32ee74864450409f6a6e"
         ),
         .binaryTarget(
             name: "RUNAMediationAdapter",

--- a/RUNA/1.17.0/RUNA.podspec
+++ b/RUNA/1.17.0/RUNA.podspec
@@ -1,0 +1,56 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNA"
+  s.version      = "1.17.0"
+  s.swift_version = '5.0'
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :git => "https://github.com/rakuten-ads/Rakuten-Ads-iOS.git"
+  }
+
+  s.default_subspec = 'Banner'
+
+  s.subspec 'CoreOnly' do |ss|
+    ss.ios.dependency 'RUNACore', '1.8.5'
+  end
+
+  s.subspec 'Banner' do |ss|
+    ss.dependency 'RUNA/CoreOnly'
+    ss.ios.dependency 'RUNABanner', '1.15.0'
+  end
+
+  s.subspec 'OMSDK' do |ss|
+    ss.ios.dependency 'RUNAOMSDK', '1.5.2'
+  end
+
+  s.subspec 'OMAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.dependency 'RUNA/OMSDK'
+    ss.ios.dependency 'RUNAOMAdapter', '1.3.3'
+  end
+
+  s.subspec 'MediationAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.ios.dependency 'Google-Mobile-Ads-SDK', '~> 11.5'
+    ss.ios.dependency 'RUNAMediationAdapter', '1.0.1'
+  end
+
+end

--- a/RUNABanner/1.15.0/RUNABanner.podspec
+++ b/RUNABanner/1.15.0/RUNABanner.podspec
@@ -1,0 +1,32 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNABanner"
+  s.version      = "1.15.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNACore', '~> 1.8'
+
+end

--- a/RUNAOMAdapter/1.3.3/RUNAOMAdapter.podspec
+++ b/RUNAOMAdapter/1.3.3/RUNAOMAdapter.podspec
@@ -1,0 +1,33 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMAdapter"
+  s.version      = "1.3.3"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNABanner', '~> 1.15'
+  s.dependency 'RUNAOMSDK', '~> 1.5.2'
+
+end

--- a/RUNAOMSDK/1.5.2/RUNAOMSDK.podspec
+++ b/RUNAOMSDK/1.5.2/RUNAOMSDK.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMSDK"
+  s.version      = "1.5.2"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "10.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "OMSDK_Rakuten.xcframework"
+
+  s.frameworks = "Foundation", "UIKit"
+
+end

--- a/doc/bannerads/README.md
+++ b/doc/bannerads/README.md
@@ -107,9 +107,13 @@ Add `pod 'OMAdapter'` into the `Podfile` will enable open measurement feature au
 RUNA SDK provides video control method for video ads. 
 It can be used at a scean like that we need to pause a video ad is shown in background view.
 
-- **(void) toggleVideoAdPlay:(BOOL) shouldPlay;**<br>
+- **(void) toggleVideoAdPlay:(BOOL) shouldPlay**<br>
   - `shouldPlay`: Bool, Value `true` to play and `false` to pause.
 
+### Get SDK Version String
+The RUNA SDK is composed of multiple modules, such as Core, Banner, and others. Each module follows its own versioning system, and the overall RUNA SDK version is determined by the versions of these individual modules.
+
+- __+(NSString*) RUNASDKVersionString__<br>
 
 ### Extensions
 

--- a/doc/ja/bannerads/README.md
+++ b/doc/ja/bannerads/README.md
@@ -112,6 +112,11 @@ RUNA SDKがビデオ広告の再生コントロール方法を提供していま
 - **(void) toggleVideoAdPlay:(BOOL) shouldPlay;**<br>
   - `shouldPlay`: Bool, 値`true`は再生する、`false`は中断する。
 
+### SDKバージョン取得
+RUNA SDKは、CoreやBannerなどの複数のモジュールで構成されています。各モジュールはそれぞれ独自のバージョン管理を行っており、RUNA SDK全体のバージョンはこれらのモジュールのバージョンによって決定されます。
+
+- __+(NSString*) RUNASDKVersionString__<br>
+
 ### 拡張設定
 
 参照先: [拡張モジュール](./extension/README.md)


### PR DESCRIPTION
## Changes
- new API: `RUNASDKVersionString` to get overall SDK version, as `1.17.0` for current release
- new version of `OMSDK` has deprecated bitcode stripped.

## Modules
__RUNA 1.17.0__

- RUNA/Banner 1.14.6 → 1.15.0
- RUNA/Core 1.8.5
- RUNA/OMAdapter 1.3.2 -> 1.3.3
- RUNA/OMSDK 1.4.13 -> 1.5.2
- RUNAMediationAdapter 1.0.1