### PR TITLE
Release/1.19.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,18 +42,18 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "RUNACore",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.8.6.xcframework.zip",
-			checksum : "7bf06017eb234594dee7c93e66017f04f520592e89983e22962333eb95a6ee88"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNACore/RUNACore_iOS_1.9.0.xcframework.zip",
+			checksum : "fc1e55c5c7fb4ba55fdf8fbdd9abfa7287ac5b3e70094e73f19436ea4724abec"
         ),
         .binaryTarget(
             name: "RUNABanner",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.16.0.xcframework.zip",
-			checksum : "fc28652ca102b22b4800a59a449743103cc49fc25e4c12b7182b76dfb2f3eda6"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNABanner/RUNABanner_iOS_1.17.0.xcframework.zip",
+			checksum : "6dcca3ed55f400050630c9f421d242c1f8d4e0b36d43bfc639ac9641debdd9ae"
         ),
         .binaryTarget(
             name: "RUNAOMAdapter",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.4.xcframework.zip",
-			checksum : "abd0022da3b0960dbb5d05c51b4dcdd3dbb2fa51a9dd8df969e7b2d00deedde5"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAOMAdapter/RUNAOMAdapter_iOS_1.3.5.xcframework.zip",
+			checksum : "7f39325926c7d5a2458b752dc716f4481b1515f6ab0403bcd8d293b53d305cfe"
         ),
         .binaryTarget(
             name: "OMSDK_Rakuten",
@@ -62,8 +62,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "RUNAMediationAdapter",
-            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAMediationAdapter/RUNAMediationAdapter_iOS_1.0.2.xcframework.zip",
-			checksum : "83590cc2f2e3cd64e9eb8d70d85bbf30a0df36aa04e98128464793bed029e221"
+            url: "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/RUNAMediationAdapter/RUNAMediationAdapter_iOS_1.0.3.xcframework.zip",
+			checksum : "ce2c15005a9b48d2cb8c7664c35a30aae1a485241934bebeb2d6093beb6562f2"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 ### [Ad Formats](#ad-formats)
 
 - **[Banner Ad](./doc/bannerads/README.md)**
+- **[Video Ad](./doc/videoad/README.md)**
 - **[CarouselAds](./doc/bannerads/carousel/README.md)**
 - **[Interstitial Ad](./doc/interstitial/README.md)**
 

--- a/RUNA/1.19.0/RUNA.podspec
+++ b/RUNA/1.19.0/RUNA.podspec
@@ -1,0 +1,56 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNA"
+  s.version      = "1.19.0"
+  s.swift_version = '5.0'
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :git => "https://github.com/rakuten-ads/Rakuten-Ads-iOS.git"
+  }
+
+  s.default_subspec = 'Banner'
+
+  s.subspec 'CoreOnly' do |ss|
+    ss.ios.dependency 'RUNACore', '1.9.0'
+  end
+
+  s.subspec 'Banner' do |ss|
+    ss.dependency 'RUNA/CoreOnly'
+    ss.ios.dependency 'RUNABanner', '1.17.0'
+  end
+
+  s.subspec 'OMSDK' do |ss|
+    ss.ios.dependency 'RUNAOMSDK', '1.5.2'
+  end
+
+  s.subspec 'OMAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.dependency 'RUNA/OMSDK'
+    ss.ios.dependency 'RUNAOMAdapter', '1.3.5'
+  end
+
+  s.subspec 'MediationAdapter' do |ss|
+    ss.dependency 'RUNA/Banner'
+    ss.ios.dependency 'Google-Mobile-Ads-SDK', '~> 11.5'
+    ss.ios.dependency 'RUNAMediationAdapter', '1.0.3'
+  end
+
+end

--- a/RUNABanner/1.17.0/RUNABanner.podspec
+++ b/RUNABanner/1.17.0/RUNABanner.podspec
@@ -1,0 +1,32 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNABanner"
+  s.version      = "1.17.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNACore', '~> 1.9'
+
+end

--- a/RUNACore/1.9.0/RUNACore.podspec
+++ b/RUNACore/1.9.0/RUNACore.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint RUNACore.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNACore"
+  s.version      = "1.9.0"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit", "Network"
+
+end

--- a/RUNAMediationAdapter/1.0.3/RUNAMediationAdapter.podspec
+++ b/RUNAMediationAdapter/1.0.3/RUNAMediationAdapter.podspec
@@ -1,0 +1,33 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAMediationAdapter"
+  s.version      = "1.0.3"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNABanner', '~> 1.17'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 11.5'
+  s.swift_version = '5.0'
+end

--- a/RUNAOMAdapter/1.3.5/RUNAOMAdapter.podspec
+++ b/RUNAOMAdapter/1.3.5/RUNAOMAdapter.podspec
@@ -1,0 +1,33 @@
+#
+#  Be sure to run `pod spec lint RUNA.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  s.name         = "RUNAOMAdapter"
+  s.version      = "1.3.5"
+  s.summary      = "Podspec file of #{s.name} iOS SDK."
+  s.description  = <<-DESC
+This repository is used to distribute #{s.name} iOS SDK for CocoaPods users.
+                   DESC
+  s.homepage     = "https://github.com/rakuten-ads/Rakuten-Ads-iOS"
+  s.license      = {
+    :type => "Copyright",
+    :text => "Copyright © Rakuten, inc. All Rights Reserved."
+  }
+  s.author       = "Rakuten"
+  s.platform     = :ios, "13.0"
+  s.source       = {
+    :http => "https://storage.googleapis.com/rssp-dev-cdn/sdk/ios/prod/#{s.name}/#{s.name}_iOS_#{s.version}.xcframework.zip"
+  }
+  s.vendored_frameworks = "#{s.name}.xcframework"
+
+  s.frameworks = "Foundation", "AdSupport", "SystemConfiguration", "WebKit", "UIKit"
+  s.dependency 'RUNABanner', '~> 1.17'
+  s.dependency 'RUNAOMSDK', '~> 1.5.2'
+
+end

--- a/doc/ja/videoad/README.md
+++ b/doc/ja/videoad/README.md
@@ -1,0 +1,325 @@
+[TOP](../README.md#top)　>　 Video Ad View
+
+---
+
+# RUNAVideoAdView
+
+**RUNABanner 1.17.0** / **RUNA 1.19.0** 以降で利用可能。
+
+`RUNAVideoAdView` は `UIView` のサブクラスで、組み込みの `WKWebView` 内に VAST 4.0 動画広告をレンダリングします。広告の読み込み、表示内計測（自動再生／自動一時停止）、インプレッションおよびインビュートラッキング、クリック処理を担います。
+
+---
+
+## 要件
+
+- `RUNABanner` フレームワーク（`RUNACore` に依存）
+- 有効な VAST 4.0 XML 文字列
+
+---
+
+## 主要クラス
+
+### RUNAAdContent
+
+ビューに渡す広告データを保持します。
+
+```objc
+@interface RUNAAdContent : NSObject
+
+@property (nonatomic, copy) NSString *vastXml;              // 必須
+@property (nonatomic, copy, nullable) NSString *impURL;     // 任意：インプレッショントラッキング URL
+@property (nonatomic, copy, nullable) NSString *inviewURL;  // 任意：インビュートラッキング URL
+
+- (instancetype)initWithVastXml:(NSString *)vastXml;
+
+@end
+```
+
+`init` および `new` は使用不可 — 必ず `initWithVastXml:` を使用してください。
+
+---
+
+### RUNAVideoAdView
+
+```objc
+@interface RUNAVideoAdView : UIView
+
+// ロード後は読み取り専用
+@property (nonatomic, readonly) RUNAAdContent *adContent;
+@property (nonatomic, readonly, nullable) NSString *clickURL;
+
+// ロード前に設定可能
+@property (nonatomic) BOOL shouldPreventDefaultClickAction;  // デフォルト: NO
+@property (nonatomic) BOOL disableBorderAdjustment;          // デフォルト: NO
+@property (nonatomic) BOOL enableSystemFontScaling;          // デフォルト: NO
+
+- (void)loadAdContent:(RUNAAdContent *)adContent
+     withEventHandler:(nullable void (^)(RUNAVideoAdView *_Nullable adView,
+                                         struct RUNAVideoAdEvent event))handler
+    NS_SWIFT_NAME(load(adContent:eventHandler:));
+
+- (void)toggleVideoAdPlay:(BOOL)shouldPlay;
+
+@end
+```
+
+#### プロパティ
+
+| プロパティ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `adContent` | `RUNAAdContent *`（読み取り専用） | — | ビューに読み込む基本データを持つコンテンツ。 |
+| `clickURL` | `NSString *`（読み取り専用、nullable） | — | VAST 広告が報告するクリックスルー URL。`.clicked` イベント時に利用可能。 |
+| `shouldPreventDefaultClickAction` | `BOOL` | `NO` | `YES` のとき、SDK はシステムブラウザで `clickURL` を開きません。イベントハンドラ経由で自前処理してください。 |
+| `disableBorderAdjustment` | `BOOL` | `NO` | `YES` のとき、広告コンテンツに適用される自動ボーダーフィットを無効にします。 |
+| `enableSystemFontScaling` | `BOOL` | `NO` | `YES` のとき、ビュー内の Web コンテンツがユーザーのシステムフォントサイズに合わせてスケールします。 |
+
+#### メソッド
+
+**`load(adContent:eventHandler:)`**
+
+動画広告の読み込みを開始します。`eventHandler` ブロックはライフサイクルイベントごとにメインスレッドで呼び出されます。このメソッドを呼び出す前にすべての設定プロパティをセットしてください。
+
+**`toggleVideoAdPlay(_:)`**
+
+再生を手動で制御します。`true` で再生／再開、`false` で一時停止／停止します。SDK は表示内の可視性に基づいて自動的に呼び出しますが、アプリのライフサイクルと同期させるために使用できます（例：`didBecomeActiveNotification` での再開）。
+
+---
+
+### RUNAVideoAdEvent
+
+```objc
+struct RUNAVideoAdEvent {
+    RUNAVideoAdEventType eventType;
+    RUNAVideoAdError error;
+};
+```
+
+#### RUNAVideoAdEventType
+
+| 値 | 説明 |
+|---|---|
+| `.succeeded` | 広告が正常にレンダリングされました。ビューの表示準備が整っています。 |
+| `.failed` | 広告が失敗しました。原因は `event.error` で確認してください。 |
+| `.clicked` | ユーザーが広告をタップしました。`adView?.clickURL` にクリックスルー URL が入ります。 |
+
+#### RUNAVideoAdError
+
+| 値 | 説明 |
+|---|---|
+| `.none` | エラーなし（`.succeeded` に付随）。 |
+| `.notReady` | 必須入力が不足しています — `adContent` が nil、または `vastXml` が空です。 |
+| `.internal` | SDK 内部エラー。無効なリソースや不正な VAST XML など。 |
+| `.network` | ネットワークリクエストまたは `WKWebView` のナビゲーションが失敗しました。 |
+| `.fatal` | 回復不能な SDK 状態。 |
+
+---
+
+## 実装サンプル（Swift）
+
+### 最小構成 — 読み込みと表示
+
+```swift
+import UIKit
+import RUNABanner
+
+class MyViewController: UIViewController {
+
+    private let videoAdView = RUNAVideoAdView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupVideoAdView()
+        loadAd()
+    }
+
+    private func setupVideoAdView() {
+        view.addSubview(videoAdView)
+        videoAdView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            videoAdView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoAdView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoAdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            videoAdView.heightAnchor.constraint(equalToConstant: 180),
+        ])
+    }
+
+    private func loadAd() {
+        let adContent = RUNAAdContent(vastXml: "<VAST version=\"4.0\">...</VAST>")
+
+        videoAdView.load(adContent: adContent) { [weak self] adView, event in
+            switch event.eventType {
+            case .succeeded:
+                print("広告を読み込みました")
+            case .failed:
+                print("広告の読み込みに失敗しました: \(event.error)")
+            case .clicked:
+                print("広告がクリックされました: \(adView?.clickURL ?? "")")
+            default:
+                break
+            }
+        }
+    }
+}
+```
+
+### フル構成 — トラッキング URL、カスタムクリック処理、アプリライフサイクル連携
+
+```swift
+import UIKit
+import RUNABanner
+import SafariServices
+
+class VideoAdViewController: UIViewController {
+
+    private let videoAdView = RUNAVideoAdView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureVideoAdView()
+        fetchAndLoad()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func appDidBecomeActive() {
+        videoAdView.toggleVideoAdPlay(true)
+    }
+
+    private func configureVideoAdView() {
+        // クリックを横取りして Safari の代わりにアプリ内ブラウザで開く
+        videoAdView.shouldPreventDefaultClickAction = true
+        // ユーザーの優先テキストサイズを尊重する
+        videoAdView.enableSystemFontScaling = true
+
+        view.addSubview(videoAdView)
+        videoAdView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            videoAdView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoAdView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoAdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            videoAdView.heightAnchor.constraint(equalToConstant: 250),
+        ])
+    }
+
+    // 例: RUNA RTB API から VAST XML を取得して読み込む
+    private func fetchAndLoad() {
+        let postBody: [String: Any] = [
+            "imp": [[
+                "banner": ["api": [7]],
+                "ext": [
+                    "adspot_id": "<YOUR_ADSPOT_ID>",
+                    "json": ["targeting": ["kw": ["<YOUR_KEYWORD>"]]]
+                ]
+            ]]
+        ]
+
+        var request = URLRequest(url: URL(string: "<RUNA_ENDPOINT>")!)
+        request.httpMethod = "POST"
+        request.httpBody = try? JSONSerialization.data(withJSONObject: postBody)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let bid = (json["seatbid"] as? [[String: Any]])?.first?["bid"]
+                             .flatMap({ $0 as? [[String: Any]] })?.first,
+                  let ext = bid["ext"] as? [String: Any],
+                  let vastXml = ext["vast_xml"] as? String else { return }
+
+            let adContent = RUNAAdContent(vastXml: vastXml)
+            adContent.impURL    = ext["impression_url"] as? String
+            adContent.inviewURL = ext["inview_url"] as? String
+
+            DispatchQueue.main.async {
+                self?.load(adContent: adContent)
+            }
+        }.resume()
+    }
+
+    private func load(adContent: RUNAAdContent) {
+        videoAdView.load(adContent: adContent) { [weak self] adView, event in
+            guard let self else { return }
+            switch event.eventType {
+            case .succeeded:
+                print("動画広告を読み込みました")
+
+            case .failed:
+                print("動画広告の読み込みに失敗しました: error=\(event.error.rawValue)")
+
+            case .clicked:
+                guard videoAdView.shouldPreventDefaultClickAction,
+                      let urlString = adView?.clickURL,
+                      let url = URL(string: urlString) else { return }
+                let safari = SFSafariViewController(url: url)
+                safari.modalPresentationStyle = .pageSheet
+                safari.delegate = self
+                self.present(safari, animated: true)
+
+            default:
+                break
+            }
+        }
+    }
+}
+
+extension VideoAdViewController: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        videoAdView.toggleVideoAdPlay(true)
+    }
+}
+```
+
+---
+
+## 計測の動作
+
+SDK は追加のセットアップなしに計測を自動的に管理します:
+
+- **インプレッション** — 広告が読み込まれて最初に表示されたときに `impURL` を一度送信します。
+- **インビュー** — 広告が継続して 2 秒間表示されたときに `inviewURL` を送信します（MRC 標準に準拠）。画面外に出た後に再び表示領域に入るたびに再送信します。
+- **自動再生／自動一時停止** — ビューが表示領域内にあるときに動画プレーヤーが再生し、スクロールアウトすると一時停止します。`toggleVideoAdPlay(_:)` を呼び出してこの動作を上書きできます（例：`applicationDidBecomeActive` 時など）。
+
+---
+
+## UITableView への組み込み
+
+`RUNAVideoAdView` は通常の `UIView` です — 他のサブビューと同様に `UITableViewCell` 内に配置してください。SDK が引き続き可視性を計測できるよう、セルとビューの両方に強参照を保持してください。
+
+```swift
+class VideoAdCell: UITableViewCell {
+    let videoAdView = RUNAVideoAdView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(videoAdView)
+        videoAdView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            videoAdView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            videoAdView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            videoAdView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            videoAdView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+    }
+    required init?(coder: NSCoder) { fatalError() }
+}
+```
+
+> ロード済みの `RUNAVideoAdView` を持つセルを `dequeueReusableCell` で再利用しないでください。広告行には毎回新たにセルを生成して直接返すことで、再利用による競合を回避できます。
+
+---
+
+[TOP](../README.md#top)
+---
+
+LANGUAGE :
+
+> [![en](/doc/lang/en.png)](/doc/videoad/README.md)

--- a/doc/videoad/README.md
+++ b/doc/videoad/README.md
@@ -1,0 +1,326 @@
+[TOP](/README.md#top)　>　 Banner Ads
+
+---
+
+# RUNAVideoAdView
+
+Available from **RUNABanner 1.17.0** / **RUNA 1.19.0**.
+
+`RUNAVideoAdView` is a `UIView` subclass that renders a VAST 4.0 video ad inside an embedded `WKWebView`. It handles ad loading, in-view measurement (auto-play / auto-pause), impression and inview tracking, and click handling.
+
+---
+
+## Requirements
+
+- `RUNABanner` framework (which depends on `RUNACore`)
+- A valid VAST 4.0 XML string
+
+---
+
+## Key Classes
+
+### RUNAAdContent
+
+Carries the ad data passed to the view.
+
+```objc
+@interface RUNAAdContent : NSObject
+
+@property (nonatomic, copy) NSString *vastXml;              // Required
+@property (nonatomic, copy, nullable) NSString *impURL;     // Optional impression tracking URL
+@property (nonatomic, copy, nullable) NSString *inviewURL;  // Optional inview tracking URL
+
+- (instancetype)initWithVastXml:(NSString *)vastXml;
+
+@end
+```
+
+`init` and `new` are unavailable — always use `initWithVastXml:`.
+
+---
+
+### RUNAVideoAdView
+
+```objc
+@interface RUNAVideoAdView : UIView
+
+// Read-only after load
+@property (nonatomic, readonly) RUNAAdContent *adContent;
+@property (nonatomic, readonly, nullable) NSString *clickURL;
+
+// Configurable before load
+@property (nonatomic) BOOL shouldPreventDefaultClickAction;  // default: NO
+@property (nonatomic) BOOL disableBorderAdjustment;          // default: NO
+@property (nonatomic) BOOL enableSystemFontScaling;          // default: NO
+
+- (void)loadAdContent:(RUNAAdContent *)adContent
+     withEventHandler:(nullable void (^)(RUNAVideoAdView *_Nullable adView,
+                                         struct RUNAVideoAdEvent event))handler
+    NS_SWIFT_NAME(load(adContent:eventHandler:));
+
+- (void)toggleVideoAdPlay:(BOOL)shouldPlay;
+
+@end
+```
+
+#### Properties
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `adContent` | `RUNAAdContent *` (readonly) | — | The content with essential data to be loaded into the view. |
+| `clickURL` | `NSString *` (readonly, nullable) | — | The click-through URL reported by the VAST ad. Available in the `.clicked` event. |
+| `shouldPreventDefaultClickAction` | `BOOL` | `NO` | When `YES`, the SDK does not open `clickURL` in the system browser. Handle the click yourself via the event handler. |
+| `disableBorderAdjustment` | `BOOL` | `NO` | When `YES`, disables the automatic border-fitting applied to ad content. |
+| `enableSystemFontScaling` | `BOOL` | `NO` | When `YES`, the web content inside the view scales with the user's system font size. |
+
+#### Methods
+
+**`load(adContent:eventHandler:)`**
+
+Starts loading the video ad. The `eventHandler` block is called on the main thread for each lifecycle event. Set all configuration properties before calling this method.
+
+**`toggleVideoAdPlay(_:)`**
+
+Manually controls playback. Pass `true` to play/resume and `false` to pause/stop. The SDK calls this automatically based on in-view visibility, but you can use it to sync with your app's lifecycle (e.g., resume on `didBecomeActiveNotification`).
+
+---
+
+### RUNAVideoAdEvent
+
+```objc
+struct RUNAVideoAdEvent {
+    RUNAVideoAdEventType eventType;
+    RUNAVideoAdError error;
+};
+```
+
+#### RUNAVideoAdEventType
+
+| Value | Description |
+|---|---|
+| `.succeeded` | Ad rendered successfully. The view is ready to display. |
+| `.failed` | Ad failed. Check `event.error` for the reason. |
+| `.clicked` | User tapped the ad. `adView?.clickURL` contains the click-through URL. |
+
+#### RUNAVideoAdError
+
+| Value | Description |
+|---|---|
+| `.none` | No error (accompanies `.succeeded`). |
+| `.notReady` | Missing required input — `adContent` was nil or `vastXml` was empty. |
+| `.internal` | SDK internal error, e.g. invalid resources or malformed VAST XML. |
+| `.network` | Network request or `WKWebView` navigation failed. |
+| `.fatal` | Unrecoverable SDK state. |
+
+---
+
+## Implementation Sample (Swift)
+
+### Minimal — load and display
+
+```swift
+import UIKit
+import RUNABanner
+
+class MyViewController: UIViewController {
+
+    private let videoAdView = RUNAVideoAdView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupVideoAdView()
+        loadAd()
+    }
+
+    private func setupVideoAdView() {
+        view.addSubview(videoAdView)
+        videoAdView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            videoAdView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoAdView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoAdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            videoAdView.heightAnchor.constraint(equalToConstant: 180),
+        ])
+    }
+
+    private func loadAd() {
+        let adContent = RUNAAdContent(vastXml: "<VAST version=\"4.0\">...</VAST>")
+
+        videoAdView.load(adContent: adContent) { [weak self] adView, event in
+            switch event.eventType {
+            case .succeeded:
+                print("Ad loaded")
+            case .failed:
+                print("Ad failed: \(event.error)")
+            case .clicked:
+                print("Ad clicked: \(adView?.clickURL ?? "")")
+            default:
+                break
+            }
+        }
+    }
+}
+```
+
+### Full — with tracking URLs, custom click handling, and app lifecycle
+
+```swift
+import UIKit
+import RUNABanner
+import SafariServices
+
+class VideoAdViewController: UIViewController {
+
+    private let videoAdView = RUNAVideoAdView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureVideoAdView()
+        fetchAndLoad()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func appDidBecomeActive() {
+        videoAdView.toggleVideoAdPlay(true)
+    }
+
+    private func configureVideoAdView() {
+        // Intercept clicks — open in an in-app browser instead of Safari
+        videoAdView.shouldPreventDefaultClickAction = true
+        // Respect the user's preferred text size
+        videoAdView.enableSystemFontScaling = true
+
+        view.addSubview(videoAdView)
+        videoAdView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            videoAdView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            videoAdView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            videoAdView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            videoAdView.heightAnchor.constraint(equalToConstant: 250),
+        ])
+    }
+
+    // Example: fetch VAST XML from the RUNA RTB API, then load
+    private func fetchAndLoad() {
+        let postBody: [String: Any] = [
+            "imp": [[
+                "banner": ["api": [7]],
+                "ext": [
+                    "adspot_id": "<YOUR_ADSPOT_ID>",
+                    "json": ["targeting": ["kw": ["<YOUR_KEYWORD>"]]]
+                ]
+            ]]
+        ]
+
+        var request = URLRequest(url: URL(string: "<RUNA_ENDPOINT>")!)
+        request.httpMethod = "POST"
+        request.httpBody = try? JSONSerialization.data(withJSONObject: postBody)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, _, _ in
+            guard let data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let bid = (json["seatbid"] as? [[String: Any]])?.first?["bid"]
+                             .flatMap({ $0 as? [[String: Any]] })?.first,
+                  let ext = bid["ext"] as? [String: Any],
+                  let vastXml = ext["vast_xml"] as? String else { return }
+
+            let adContent = RUNAAdContent(vastXml: vastXml)
+            adContent.impURL    = ext["impression_url"] as? String
+            adContent.inviewURL = ext["inview_url"] as? String
+
+            DispatchQueue.main.async {
+                self?.load(adContent: adContent)
+            }
+        }.resume()
+    }
+
+    private func load(adContent: RUNAAdContent) {
+        videoAdView.load(adContent: adContent) { [weak self] adView, event in
+            guard let self else { return }
+            switch event.eventType {
+            case .succeeded:
+                print("Video ad loaded")
+
+            case .failed:
+                print("Video ad failed: error=\(event.error.rawValue)")
+
+            case .clicked:
+                guard videoAdView.shouldPreventDefaultClickAction,
+                      let urlString = adView?.clickURL,
+                      let url = URL(string: urlString) else { return }
+                let safari = SFSafariViewController(url: url)
+                safari.modalPresentationStyle = .pageSheet
+                safari.delegate = self
+                self.present(safari, animated: true)
+
+            default:
+                break
+            }
+        }
+    }
+}
+
+extension VideoAdViewController: SFSafariViewControllerDelegate {
+    func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        videoAdView.toggleVideoAdPlay(true)
+    }
+}
+```
+
+---
+
+## Measurement Behavior
+
+The SDK automatically manages measurement without any additional setup:
+
+- **Impression** — fires `impURL` once when the ad is loaded and initially visible.
+- **Inview** — fires `inviewURL` when the ad has been continuously visible for 2 seconds, conforming to the MRC standard. Re-fires each time the view re-enters the viewport after being off-screen.
+- **Auto-play / auto-pause** — the video player plays when the view is in-view and pauses when it scrolls out. Call `toggleVideoAdPlay(_:)` to override this, for example on `applicationDidBecomeActive`.
+
+---
+
+## Embedding in a UITableView
+
+`RUNAVideoAdView` is a plain `UIView` — place it inside a `UITableViewCell` the same way as any other subview. Keep a strong reference to both the cell and the view so the SDK can continue measuring visibility.
+
+```swift
+class VideoAdCell: UITableViewCell {
+    let videoAdView = RUNAVideoAdView()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        contentView.addSubview(videoAdView)
+        videoAdView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            videoAdView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            videoAdView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            videoAdView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            videoAdView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+    }
+    required init?(coder: NSCoder) { fatalError() }
+}
+```
+
+> Do not reuse a cell that holds a loaded `RUNAVideoAdView` via `dequeueReusableCell`. Allocate the ad cell once and return it directly for the ad row to avoid reuse conflicts.
+
+---
+
+[TOP](/README.md#top)
+
+---
+
+LANGUAGE :
+
+> [![ja](/doc/lang/ja.png)](/doc/ja/videoad/README.md)


### PR DESCRIPTION
## Changes
- new API: `RUNAVideoAdView` to renders a VAST 4.0 video ad, details refer to the document
- new API: `enableSystemFontScaling` in `RUNABannerView`, when `YES`, the web content inside the view scales with the user's system font size.
- deduplication of the same view imp URL has been sent
- fix the default value of OM verification URL & partner SDK version string
- rebuild modules of SDK except module `RakutenOMSDK` in Xcode 26.0.1 due to the [Apple announcement](https://developer.apple.com/news/?id=ueeok6yw)

> [!NOTE]
> `RakutenOMSDK` rebuilt in Xcode 26 is still in progress with support from a third party.

## Modules
RUNA(1.19.0)
-Core(1.9.0)
-Baner(1.17.0)
-OMAdapter(1.3.5)
-MediationAdapter(1.0.3)